### PR TITLE
Fix #1: Correct the typo `montor` to `monitor` in `README.md` `png`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Upptime](https://user-images.githubusercontent.com/73812536/97834147-1932df00-1cfd-11eb-8e1f-0a93c554258e.png)](https://github.com/upptime/upptime)
+[![Upptime](https://user-images.githubusercontent.com/12752145/231535261-129454ef-4ee3-47e2-a3d2-12dd726c0fda.png)](https://github.com/upptime/upptime)


### PR DESCRIPTION
Note that I used Gimp to copy and paste the `i` of `uptime` to keep the text style while part both sides before `mon` and after `tor` with 12 pixels to keep the `i` centered and separated by 4 pixels between `n` and `t`.